### PR TITLE
Make keypair prefix configurable

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -55,6 +55,9 @@ var (
 	ldapUseInsecure         bool
 
 	tokenTtl time.Duration
+
+	// prefix for keypair files (.priv and .pub)
+	keypairPrefix string
 )
 
 // RootCmd represents the serve command
@@ -69,9 +72,6 @@ var RootCmd = &cobra.Command{
 		serve()
 	},
 }
-
-// KeypairFilename to be used
-const KeypairFilename = "signing"
 
 // Execute adds all child commands to the root command and sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
@@ -109,6 +109,8 @@ func init() {
 	RootCmd.Flags().BoolVar(&ldapUseInsecure, "use-insecure", false, "Disable LDAP TLS")
 
 	RootCmd.Flags().DurationVar(&tokenTtl, "token-ttl", 24*time.Hour, "TTL for the token")
+
+	RootCmd.Flags().StringVar(&keypairPrefix, "keypair-prefix", "signing", "Path prefix for keypair files.")
 
 	viper.BindPFlags(RootCmd.Flags())
 	flag.CommandLine.Parse([]string{})
@@ -169,6 +171,7 @@ func validate() {
 		fmt.Fprintf(os.Stderr, "file %s does not exist\n", serverTlsPrivateKeyFile)
 		os.Exit(1)
 	}
+	keypairPrefix = viper.GetString("keypair-prefix")
 }
 
 func requireFlag(flagName string, flagValue string) {
@@ -179,18 +182,17 @@ func requireFlag(flagName string, flagValue string) {
 }
 
 func serve() error {
-	keypairFilename := "signing"
-	if err := token.GenerateKeypair(keypairFilename); err != nil {
+	if err := token.GenerateKeypair(keypairPrefix); err != nil {
 		glog.Errorf("Error generating key pair: %v", err)
 	}
 
 	var err error
-	tokenSigner, err := token.NewSigner(keypairFilename)
+	tokenSigner, err := token.NewSigner(keypairPrefix)
 	if err != nil {
 		glog.Errorf("Error creating token issuer: %v", err)
 	}
 
-	tokenVerifier, err := token.NewVerifier(keypairFilename)
+	tokenVerifier, err := token.NewVerifier(keypairPrefix)
 	if err != nil {
 		glog.Errorf("Error creating token verifier: %v", err)
 	}

--- a/token/signer.go
+++ b/token/signer.go
@@ -28,7 +28,7 @@ func NewSigner(filename string) (Signer, error) {
 	// of it. Go correctly checks that points are on the curve. A
 	// version of Go > 1.4 is recommended, because ECDSA signatures
 	// in previous versions are unsafe.
-	key, err := ioutil.ReadFile(filename + ".priv")
+	key, err := ioutil.ReadFile(filename)
 	if err != nil {
 		return nil, err
 	}

--- a/token/token.go
+++ b/token/token.go
@@ -38,7 +38,7 @@ func GenerateKeypair(filename string) (err error) {
 	if err != nil {
 		return err
 	}
-	err = ioutil.WriteFile(filename+".priv", keyPEM, os.FileMode(0600))
+	err = ioutil.WriteFile(filename, keyPEM, os.FileMode(0600))
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
allowing to pass a path like /var/lib/kubernetes-ldap/keypair, where
.priv and .pub files will be created

--keypair-prefix defaults to previous behavior, signing.priv/.pub in current directory.

Addresses https://github.com/proofpoint/kubernetes-ldap/issues/14