### PR TITLE
Add gen-keypair subcommand

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -182,8 +182,12 @@ func requireFlag(flagName string, flagValue string) {
 }
 
 func serve() error {
-	if err := token.GenerateKeypair(keypairPrefix); err != nil {
-		glog.Errorf("Error generating key pair: %v", err)
+	if token.KeypairExists(keypairPrefix) {
+		glog.Infof("Using existing keypair in %v", keypairPrefix)
+	} else {
+		if err := token.GenerateKeypair(keypairPrefix); err != nil {
+			glog.Errorf("Error generating key pair: %v", err)
+		}
 	}
 
 	var err error

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -55,6 +55,9 @@ var (
 	ldapUseInsecure         bool
 
 	tokenTtl time.Duration
+
+	// prefix for keypair files (.priv and .pub)
+	keypairPrefix string
 )
 
 // RootCmd represents the serve command
@@ -69,9 +72,6 @@ var RootCmd = &cobra.Command{
 		serve()
 	},
 }
-
-// KeypairFilename to be used
-const KeypairFilename = "signing"
 
 // Execute adds all child commands to the root command and sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
@@ -109,6 +109,8 @@ func init() {
 	RootCmd.Flags().BoolVar(&ldapUseInsecure, "use-insecure", false, "Disable LDAP TLS")
 
 	RootCmd.Flags().DurationVar(&tokenTtl, "token-ttl", 24*time.Hour, "TTL for the token")
+
+	RootCmd.Flags().StringVar(&keypairPrefix, "keypair-prefix", "signing", "Path prefix for keypair files.")
 
 	viper.BindPFlags(RootCmd.Flags())
 	flag.CommandLine.Parse([]string{})
@@ -169,6 +171,7 @@ func validate() {
 		fmt.Fprintf(os.Stderr, "file %s does not exist\n", serverTlsPrivateKeyFile)
 		os.Exit(1)
 	}
+	keypairPrefix = viper.GetString("keypair-prefix")
 }
 
 func requireFlag(flagName string, flagValue string) {
@@ -179,18 +182,17 @@ func requireFlag(flagName string, flagValue string) {
 }
 
 func serve() error {
-	keypairFilename := "signing"
-	if err := token.GenerateKeypair(keypairFilename); err != nil {
+	if err := token.GenerateKeypair(keypairPrefix); err != nil {
 		glog.Errorf("Error generating key pair: %v", err)
 	}
 
 	var err error
-	tokenSigner, err := token.NewSigner(keypairFilename)
+	tokenSigner, err := token.NewSigner(keypairPrefix)
 	if err != nil {
 		glog.Errorf("Error creating token issuer: %v", err)
 	}
 
-	tokenVerifier, err := token.NewVerifier(keypairFilename)
+	tokenVerifier, err := token.NewVerifier(keypairPrefix)
 	if err != nil {
 		glog.Errorf("Error creating token verifier: %v", err)
 	}

--- a/token/token.go
+++ b/token/token.go
@@ -50,3 +50,9 @@ func GenerateKeypair(filename string) (err error) {
 	err = ioutil.WriteFile(filename+".pub", pubKeyPEM, os.FileMode(0644))
 	return
 }
+
+func KeypairExists(filename string) bool {
+	_, err1 := ioutil.ReadFile(filename + ".priv")
+	_, err2 := ioutil.ReadFile(filename + ".pub")
+	return (err1 == nil && err2 == nil)
+}


### PR DESCRIPTION
Use it like this:
```
# kubernetes-ldap --keypair-prefix /var/lib/kubernetes-ldap/keypair gen-keypair
Generated keypair in /var/lib/kubernetes-ldap/keypair.priv /var/lib/kubernetes-ldap/keypair.pub
```

Help now looks like this:
```
$ ./kubernetes-ldap -h
kubernetes-ldap exposes two endpoints:
	/ldapAuth - to get a new token
	/authenticate - to verify the token

Usage:
  kubernetes-ldap [flags]
  kubernetes-ldap [command]

Available Commands:
  gen-keypair Generate keypair for token signing/verification and exit
  help        Help about any command

Flags:
      --config string                      config file (default is $HOME/.kubernetes-ldap.yaml)
  -h, --help                               help for kubernetes-ldap
      --keypair-prefix string              Path prefix for keypair files. (default "signing")
      --ldap-base-dn string                LDAP user base DN in for form 'dc=example,dc=com
      --ldap-host string                   (Required Host or IP of the LDAP server )
      --ldap-port uint                     LDAP server port (default 389)
      --ldap-search-user-dn string         Search user DN for this app to find users (e.g.: cn=admin,dc=example,dc=com).
      --ldap-search-user-password string   Search user password
      --ldap-skip-tls-verification         Skip LDAP server TLS verification
      --ldap-user-attribute string         LDAP Username attribute for login (default "uid")
      --port uint                          Local port this proxy server will run on (default 4000)
      --tls-cert-file string               (Required) File containing x509 Certificate for HTTPS.  (CA cert, if any, concatenated after server cert) .
      --tls-private-key-file string        (Required) File containing x509 private key matching --tls-cert-file.
      --token-ttl duration                 TTL for the token (default 24h0m0s)
      --use-insecure                       Disable LDAP TLS
      --username-attribute string          ldap attribute to use for Username inside token (default "uid")

Use "kubernetes-ldap [command] --help" for more information about a command.
```
and
```
 ./kubernetes-ldap gen-keypair -h
Generates a keypair with prefix specified by --keypair-prefix.
	Keypair is written into <keypair-prefix>.priv and <keypair-prefix>.pub.

Usage:
  kubernetes-ldap gen-keypair [flags]

Flags:
  -h, --help   help for gen-keypair

Global Flags:
      --config string           config file (default is $HOME/.kubernetes-ldap.yaml)
      --keypair-prefix string   Path prefix for keypair files. (default "signing")
```
Based on #15 and #16, addresses #14 