### PR TITLE
expose expiration time in response

### DIFF
--- a/auth/token_issuer.go
+++ b/auth/token_issuer.go
@@ -106,6 +106,8 @@ func (lti *LDAPTokenIssuer) ServeHTTP(resp http.ResponseWriter, req *http.Reques
 		jsondata, err := json.Marshal(data)
 		if err != nil {
 			glog.Errorf("Error marshalling json %s", err.Error())
+			resp.WriteHeader(http.StatusInternalServerError)
+			return
 		}
 
 		resp.Header().Add("Content-Type", "application/json")

--- a/auth/token_issuer.go
+++ b/auth/token_issuer.go
@@ -3,6 +3,7 @@ package auth
 import (
 	"net/http"
 
+	"encoding/json"
 	goldap "github.com/go-ldap/ldap"
 	"github.com/golang/glog"
 	"github.com/prometheus/client_golang/prometheus"
@@ -96,6 +97,22 @@ func (lti *LDAPTokenIssuer) ServeHTTP(resp http.ResponseWriter, req *http.Reques
 	}
 
 	successfulTokens.Inc()
+	if req.Header.Get("Accept") == "application/json" {
+		data := map[string]interface{}{
+			"token":               signedToken,
+			"expirationTimestamp": token.Expiration,
+		}
+
+		jsondata, err := json.Marshal(data)
+		if err != nil {
+			glog.Errorf("Error marshalling json %s", err.Error())
+		}
+
+		resp.Header().Add("Content-Type", "application/json")
+		resp.Write(jsondata)
+		return
+	}
+
 	resp.Header().Add("Content-Type", "text/plain")
 	resp.Write([]byte(signedToken))
 }


### PR DESCRIPTION
expose expiration time in response if Accept header is application/json in request.

this is needed for our ldap client.